### PR TITLE
Added case insensitive and whitespace strippping login

### DIFF
--- a/lib/devise/orm/couchrest_model/schema.rb
+++ b/lib/devise/orm/couchrest_model/schema.rb
@@ -10,6 +10,9 @@ module Devise
         end
 
         def find_for_authentication(conditions)
+          conditions = filter_auth_params(conditions.dup)
+          (case_insensitive_keys || []).each { |k| conditions[k].try(:downcase!) }
+          (strip_whitespace_keys || []).each { |k| conditions[k].try(:strip!) }
           find(:conditions => conditions)
         end
 


### PR DESCRIPTION
When a user sign up, current version (1.4.2) of devise is doing downcase and whitespace stripping.  However, the logic is missing from login.
